### PR TITLE
Support variables such as `$-base-font-size`, `$_ENV`

### DIFF
--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -41,7 +41,7 @@
     'name': 'entity.language.stylus'
   }
   {
-    'match': '\\$[a-zA-Z][a-zA-Z0-9_-]*'
+    'match': '\\$[a-zA-Z_-][a-zA-Z0-9_-]*'
     'name': 'variable.other.language.stylus'
   }
   {


### PR DESCRIPTION
Sometimes, we need variables like this: `$-base-font-size`, it's means `global variable` (from my team's coding style, [example](https://github.com/ecomfe/rider/blob/master/lib/rider/setting.styl)).

Thanks.