### PR TITLE
Add support for autocomplete-css

### DIFF
--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.css.less'
+'scopeName': 'source.css.stylus'
 'name': 'Stylus'
 'fileTypes': [
   'styl'

--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.stylus'
+'scopeName': 'source.css.less'
 'name': 'Stylus'
 'fileTypes': [
   'styl'
@@ -31,36 +31,36 @@
 'repository':
   'comma':
     'match': '\\s*,\\s*'
-    'name': 'punctuation.delimiter.comma.stylus'
+    'name': 'punctuation.delimiter.comma.css'
   'comment_line':
     'captures':
       '1':
-        'name': 'punctuation.definition.comment.stylus'
+        'name': 'punctuation.definition.comment.css'
     'match': '(?:^[ \\t]+)?(\\/\\/).*$\\n?'
-    'name': 'comment.line.stylus'
+    'name': 'comment.line.css'
   'comment_block':
     'begin': '\\/\\*'
     'captures':
       '0':
-        'name': 'punctuation.definition.comment.stylus'
+        'name': 'punctuation.definition.comment.css'
     'end': '\\*\\/'
-    'name': 'comment.block.stylus'
+    'name': 'comment.block.css'
   'string-quoted':
     'patterns': [
       {
         'match': '\'[^\']*\''
-        'name': 'string.quoted.single.stylus'
+        'name': 'string.quoted.single.css'
       }
       {
         'match': '"[^"]*"'
-        'name': 'string.quoted.double.stylus'
+        'name': 'string.quoted.double.css'
       }
     ]
   'conditionals':
     'begin': "(^\\s*|\\s+)(if|unless|else)(?=[\\s({]|$)\\s*"
     'beginCaptures':
       '2':
-        'name': 'keyword.control.stylus'
+        'name': 'keyword.control.css'
     'end': '(?=$|\\{)'
     'patterns': [
       {
@@ -70,14 +70,14 @@
   'constant_color':
     'comment': 'http://www.w3.org/TR/CSS21/syndata.html#value-def-color'
     'match': '(?<![\\w-])(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white(?!-)|yellow)(?![\\w-])'
-    'name': 'support.constant.color.w3c-standard-color-name.stylus'
+    'name': 'support.constant.color.w3c-standard-color-name.css'
   'constant_deprecated_color':
     'comment': 'These colours are mostly recognised but will not validate. ref: http://www.w3schools.com/css/css_colornames.asp'
     'match': '(?<![\\w-])(aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|turquoise|violet|wheat|whitesmoke|yellowgreen)(?![\\w-])'
-    'name': 'invalid.deprecated.color.w3c-non-standard-color-name.stylus'
+    'name': 'invalid.deprecated.color.w3c-non-standard-color-name.css'
   'constant_font':
     'match': '((?<![\\w-])(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace)(?![\\w-]))'
-    'name': 'support.constant.font-name.stylus'
+    'name': 'support.constant.font-name.css'
   'constant_functions':
     'comment': 'Function definition (or definition when no curly braces are used)'
     'begin': '([\\w$-]+)(\\()'
@@ -85,38 +85,38 @@
       '1':
         'name': 'support.function.misc.css'
       '2':
-        'name': 'punctuation.section.function.definition.parameters.start.begin.stylus'
+        'name': 'punctuation.section.function.definition.parameters.start.begin.css'
     'end': '(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.function.definition.parameters.end.stylus'
+        'name': 'punctuation.section.function.definition.parameters.end.css'
     'patterns': [
       {
         'include': '#expression'
       }
     ]
-    'name': 'entity.function.stylus'
+    'name': 'entity.function.css'
   'constant_hex':
     'captures':
       '1':
-        'name': 'punctuation.definition.constant.stylus'
+        'name': 'punctuation.definition.constant.css'
     'match': '(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\\b'
-    'name': 'constant.other.color.rgb-value.stylus'
+    'name': 'constant.other.color.rgb-value.css'
   'constant_important':
     'match': '\\!important'
-    'name': 'keyword.other.important.stylus'
+    'name': 'keyword.other.important.css'
   'constant_number':
     'match': '[\\+|\\-]?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)'
-    'name': 'constant.numeric.stylus'
+    'name': 'constant.numeric.css'
   'constant_property_value':
     'match': '(?<![\\w-])(absolute|all(-scroll)?|always|armenian|auto|avoid|baseline|below|bidi-override|block|bold(er)?|(border|content|padding)-box|both|bottom|break-all|break-word|capitalize|center|char|circle|cjk-ideographic|col-resize|collapse|column|column-reverse|crosshair|cursive|dashed|decimal-leading-zero|decimal|default|disabled|disc|distribute-all-lines|distribute-letter|distribute-space|distribute|dotted|double|e-resize|ellipsis|fantasy|fixed|flex|flex-end|flex-start|geometricPrecision|georgian|groove|hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|initial|inherit|inline-block|inline|inset|inside|inter-ideograph|inter-word|italic|justify|katakana-iroha|katakana|keep-all|left|lighter|line-edge|line-through|line|list-item|loose|lower-alpha|lower-greek|lower-latin|lower-roman|lowercase|lr-tb|ltr|medium|middle|move|monospace|n-resize|ne-resize|newspaper|no-drop|no-repeat|nw-resize|none|normal|not-allowed|nowrap|oblique|optimize(Legibility|Quality|Speed)|outset|outside|overline|pointer|pre(-(wrap|line))?|progress|relative|repeat-x|repeat-y|repeat|right|ridge|row|row-reverse|row-resize|rtl|(sans-)?serif|s-resize|scroll|se-resize|separate|small-caps|solid|space-around|space-between|square|static|stretch|strict|sub|super|sw-resize|table(-(row|cell|footer-group|header-group))?|tb-rl|text-bottom|text-top|text|thick|thin|top|transparent|underline|upper-alpha|upper-latin|upper-roman|uppercase|vertical(-(ideographic|text))?|visible(Painted|Fill|Stroke)?|w-resize|wait|whitespace|wrap|zero|smaller|larger|((xx?-)?(small(er)?|large(r)?))|painted|fill|stroke)(?![\\w-])'
-    'name': 'support.constant.property-value.stylus'
+    'name': 'support.constant.property-value.css'
   'constant_rgb':
     'match': '(?<!scale3d\\(|translate3d\\(|rotate3d\\()(\\b0*((1?[0-9]{1,2})|(2([0-4][0-9]|5[0-5])))\\s*,\\s*)(0*((1?[0-9]{1,2})|(2([0-4][0-9]|5[0-5])))\\s*,\\s*)(0*((1?[0-9]{1,2})|(2([0-4][0-9]|5[0-5])))\\b)'
-    'name': 'constant.other.color.rgb-value.stylus'
+    'name': 'constant.other.color.rgb-value.css'
   'constant_rgb_percentage':
     'match': '\\b([0-9]{1,2}|100)\\s*%,\\s*([0-9]{1,2}|100)\\s*%,\\s*([0-9]{1,2}|100)\\s*%'
-    'name': 'constant.other.color.rgb-percentage.stylus'
+    'name': 'constant.other.color.rgb-percentage.css'
   'constant_stylus_functions':
     'patterns': [
       {
@@ -134,10 +134,10 @@
     ]
   'constant_unit':
     'match': '(?<=[\\d])(ch|cm|deg|dpi|dpcm|dppx|em|ex|grad|in|mm|ms|pc|pt|px|rad|rem|turn|s|vh|vmax|vmin|vw)\\b|%'
-    'name': 'keyword.other.unit.stylus'
+    'name': 'keyword.other.unit.css'
   'escape':
     'match': '\\\\.'
-    'name': 'constant.character.escape.stylus'
+    'name': 'constant.character.escape.css'
   'expression':
     'patterns': [
       {
@@ -214,15 +214,15 @@
     'patterns': [
       {
         'match': '\\.'
-        'name': 'punctuation.delimiter.hash.stylus'
+        'name': 'punctuation.delimiter.hash.css'
       }
       {
         'match': '\\['
-        'name': 'punctuation.definition.entity.start.stylus'
+        'name': 'punctuation.definition.entity.start.css'
       }
       {
         'match': '\\]'
-        'name': 'punctuation.definition.entity.end.stylus'
+        'name': 'punctuation.definition.entity.end.css'
       }
       {
         'include': '#string-quoted'
@@ -231,16 +231,16 @@
         'include': '#variable'
       }
     ]
-    'name': 'meta.hash-access.stylus'
+    'name': 'meta.hash-access.css'
   'hash-definition':
     'begin': '\\{'
     'beginCaptures':
         '0':
-          'name': 'punctuation.section.embedded.start.stylus'
+          'name': 'punctuation.section.embedded.start.css'
     'end': '\\}'
     'endCaptures':
         '0':
-          'name': 'punctuation.section.embedded.end.stylus'
+          'name': 'punctuation.section.embedded.end.css'
     'patterns': [
       {
         'include': '#comment_line'
@@ -249,13 +249,13 @@
         'begin': '(?:([\\w$-]+)|(\'[^\']*\')|("[^"]*"))\\s*(:)\\s*'
         'beginCaptures':
           '1':
-            'name': 'support.type.property-name.stylus'
+            'name': 'support.type.property-name.css'
           '2':
-            'name': 'string.quoted.single.stylus'
+            'name': 'string.quoted.single.css'
           '3':
-            'name': 'string.quoted.double.stylus'
+            'name': 'string.quoted.double.css'
           '4':
-            'name': 'punctuation.separator.key-value.stylus'
+            'name': 'punctuation.separator.key-value.css'
         'patterns':[
           {
             'include': '#expression'
@@ -264,21 +264,21 @@
         'end': '(;)|(?=\\}|$)'
         'endCaptures':
           '1':
-            'name': 'punctuation.terminator.statement.stylus'
+            'name': 'punctuation.terminator.statement.css'
       }
     ]
-    'name': 'meta.hash.stylus'
+    'name': 'meta.hash.css'
   'interpolation':
     'begin': '\\{([\\w]+)'
     'end': '\\}'
     'beginCaptures':
       '0':
-        'name': 'punctuation.section.embedded.start.stylus'
+        'name': 'punctuation.section.embedded.start.css'
       '1':
         'name': 'punctuation.definition.entity.css'
     'endCaptures':
       '0':
-        'name': 'punctuation.section.embedded.end.stylus'
+        'name': 'punctuation.section.embedded.end.css'
     'patterns': [
       {
         'include': '#expression'
@@ -289,7 +289,7 @@
     'begin': "(^\\s*|\\s+)(for)\\s+(?=.*?\\s+in\\s+)"
     'beginCaptures':
       '2':
-        'name': 'keyword.control.stylus'
+        'name': 'keyword.control.css'
     'end': '$|\\{'
     'patterns': [
       {
@@ -298,21 +298,21 @@
     ]
   'language-constants':
     'match': '\\b(true|false|null)\\b'
-    'name': 'constant.language.stylus'
+    'name': 'constant.language.css'
   'language-keywords':
     'patterns': [
       {
         'match': '(\\b|\\s)(return|else)\\b'
-        'name': 'keyword.control.stylus'
+        'name': 'keyword.control.css'
       }
       {
         'match': '(\\b|\\s)(!important|in|is defined|is a)\\b'
-        'name': 'keyword.other.stylus'
+        'name': 'keyword.other.css'
       }
       {
         'comment': 'Reserved variable available in all functions'
         'match': '\\barguments\\b'
-        'name': 'variable.language.stylus'
+        'name': 'variable.language.css'
       }
     ]
   'logical_operators':
@@ -324,17 +324,17 @@
         '3':
           'name': 'support.function.misc.css'
         '4':
-          'name': 'punctuation.section.function.parameters.definition.start.begin.stylus'
+          'name': 'punctuation.section.function.parameters.definition.start.begin.css'
     'end': '(\\))'
     'endCaptures':
         '1':
-          'name': 'punctuation.section.function.parameters.definition.end.stylus'
+          'name': 'punctuation.section.function.parameters.definition.end.css'
     'patterns': [
       {
         'include': '#expression'
       }
     ]
-    'name': 'entity.function.misc.stylus'
+    'name': 'entity.function.misc.css'
   'property_css':
     'begin': '(?<=^|;|{)\\s*(?=([a-zA-Z0-9_-]|(\\{(.*?)\\})|(/\\*.*?\\*/))+\\s*[:\\s]\\s*(?!(\\s*\\{))(?![^}]*?\\{[^}]*($|\\})))'
     'end': '(?=\\}|;)|(?<!,)\\s*\\n'
@@ -352,11 +352,12 @@
         'begin': '(?<!^|;|{)\\s*(?:(:)|\\s)'
         'beginCaptures':
             '1':
-              'name': 'punctuation.separator.key-value.stylus'
-        'end': '(;)|(?=\\})|(?=(?<!\\,)\\s*\\n)'
+              'name': 'punctuation.separator.key-value.css'
+        'end': '(;|\\n)|(?=\\})|(?=(?<!\\,)\\n)'
         'endCaptures':
             '1':
-              'name': 'punctuation.terminator.rule.stylus'
+              'name': 'punctuation.terminator.rule.css'
+        'name': 'meta.property-value.css'
         'patterns': [
           {
             'include': '#comment_block'
@@ -370,30 +371,37 @@
           {
             'include': '#expression'
           }
+          {
+            'include': '$self'
+          }
         ]
       }
       {
         'match': '-(moz|o|ms|webkit|khtml)-'
-        'name': 'support.type.property-name.vendor-prefix.stylus'
+        'name': 'support.type.property-name.vendor-prefix.css'
       }
       {
-        'match': '.'
-        'name': 'support.property-name.stylus'
+        'name': 'support.type.property-name.css'
+        'match': '(?<![-a-z])(-webkit-[-A-Za-z]+|-moz-[-A-Za-z]+|-o-[-A-Za-z]+|-ms-[-A-Za-z]+|-khtml-[-A-Za-z]+|zoom|z-index|y|x|wrap|word-wrap|word-spacing|word-break|word|width|widows|white-space-collapse|white-space|white|weight|volume|voice-volume|voice-stress|voice-rate|voice-pitch-range|voice-pitch|voice-family|voice-duration|voice-balance|voice|visibility|vertical-align|variant|user-select|up|unicode-bidi|unicode-range|unicode|trim|transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform|touch-action|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|text-wrap|text-transform|text-shadow|text-replace|text-rendering|text-overflow|text-outline|text-justify|text-indent|text-height|text-emphasis|text-decoration|text-align-last|text-align|text|target-position|target-new|target-name|target|table-layout|tab-size|style-type|style-position|style-image|style|string-set|stretch|stress|stacking-strategy|stacking-shift|stacking-ruby|stacking|src|speed|speech-rate|speech|speak-punctuation|speak-numeral|speak-header|speak|span|spacing|space-collapse|space|sizing|size-adjust|size|shadow|respond-to|rule-width|rule-style|rule-color|rule|ruby-span|ruby-position|ruby-overhang|ruby-align|ruby|rows|rotation-point|rotation|role|right-width|right-style|right-color|right|richness|rest-before|rest-after|rest|resource|resize|reset|replace|repeat|rendering-intent|rate|radius|quotes|punctuation-trim|punctuation|property|profile|presentation-level|presentation|position|pointer-events|point|play-state|play-during|play-count|pitch-range|pitch|phonemes|pause-before|pause-after|pause|page-policy|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|pack|overhang|overflow-y|overflow-x|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|origin|orientation|orient|ordinal-group|order|opacity|offset|numeral|new|nav-up|nav-right|nav-left|nav-index|nav-down|nav|name|move-to|model|mix-blend-mode|min-width|min-height|min|max-width|max-height|max|marquee-style|marquee-speed|marquee-play-count|marquee-direction|marquee|marks|mark-before|mark-after|mark|margin-top|margin-right|margin-left|margin-bottom|margin|mask-image|list-style-type|list-style-position|list-style-image|list-style|list|lines|line-stacking-strategy|line-stacking-shift|line-stacking-ruby|line-stacking|line-height|line-break|level|letter-spacing|length|left-width|left-style|left-color|left|label|justify-content|justify|iteration-count|inline-box-align|initial-value|initial-size|initial-before-align|initial-before-adjust|initial-after-align|initial-after-adjust|index|indent|increment|image-resolution|image-orientation|image|icon|hyphens|hyphenate-resource|hyphenate-lines|hyphenate-character|hyphenate-before|hyphenate-after|hyphenate|height|header|hanging-punctuation|grid-rows|grid-columns|grid|gap|font-kerning|font-language-override|font-weight|font-variant-caps|font-variant|font-style|font-synthesis|font-stretch|font-size-adjust|font-size|font-family|font|float-offset|float|flex-wrap|flex-shrink|flex-grow|flex-group|flex-flow|flex-direction|flex-basis|flex|fit-position|fit|fill|filter|family|empty-cells|emphasis|elevation|duration|drop-initial-value|drop-initial-size|drop-initial-before-align|drop-initial-before-adjust|drop-initial-after-align|drop-initial-after-adjust|drop|down|dominant-baseline|display-role|display-model|display|direction|delay|decoration-break|decoration|cursor|cue-before|cue-after|cue|crop|counter-reset|counter-increment|counter|count|content|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|column-break-before|column-break-after|column|color-profile|color|collapse|clip|clear|character|caption-side|break-inside|break-before|break-after|break|box-sizing|box-shadow|box-pack|box-orient|box-ordinal-group|box-lines|box-flex-group|box-flex|box-direction|box-decoration-break|box-align|box|bottom-width|bottom-style|bottom-right-radius|bottom-left-radius|bottom-color|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-length|border-left-width|border-left-style|border-left-color|border-left|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-target|bookmark-level|bookmark-label|bookmark|binding|bidi|before|baseline-shift|baseline|balance|background-blend-mode|background-size|background-repeat|background-position|background-origin|background-image|background-color|background-clip|background-break|background-attachment|background|azimuth|attachment|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-duration|animation-direction|animation-delay|animation-fill-mode|animation|alignment-baseline|alignment-adjust|alignment|align-self|align-last|align-items|align-content|align|after|adjust|will-change)(?=\\s*:?(.*\\\()|(?!.*(?<!@){))\\b'
+      }
+      {
+        'name': 'support.type.property-name.svg.css'
+        'match': '(?<![-a-z])(writing-mode|text-anchor|stroke-width|stroke-opacity|stroke-miterlimit|stroke-linejoin|stroke-linecap|stroke-dashoffset|stroke-dasharray|stroke|stop-opacity|stop-color|shape-rendering|marker-start|marker-mid|marker-end|lighting-color|kerning|image-rendering|glyph-orientation-vertical|glyph-orientation-horizontal|flood-opacity|flood-color|fill-rule|fill-opacity|fill|enable-background|color-rendering|color-interpolation-filters|color-interpolation|clip-rule|clip-path)(?=\\s*:)'
       }
     ]
   'property_list':
     'begin': '\\{'
     'beginCaptures':
       '0':
-        'name': 'punctuation.section.property-list.begin.stylus'
+        'name': 'punctuation.section.property-list.begin.css'
     'captures':
       '0':
-        'name': 'punctuation.section.property-list.stylus'
+        'name': 'punctuation.section.property-list.css'
     'end': '\\}'
     'endCaptures':
       '0':
-        'name': 'punctuation.section.property-list.end.stylus'
-    'name': 'meta.property-list.stylus'
+        'name': 'punctuation.section.property-list.end.css'
+    'name': 'meta.property-list.css'
     'patterns': [
       {
         'include': '#rules'
@@ -408,9 +416,10 @@
   'property-reference':
     'comment': 'Reference to another property'
     'match': '@[a-z-]+'
-    'name': 'variable.other.property.stylus'
+    'name': 'variable.other.property.css'
   'property_values':
     'comment': 'Stuff that should only be available on values.'
+    'name': 'meta.property-value.css'
     'patterns': [
       {
         'include': '#string_single'
@@ -459,11 +468,11 @@
     'begin': "^\\s*(return)"
     'beginCaptures':
       '1':
-        'name': 'keyword.control.stylus'
+        'name': 'keyword.control.css'
     'end': '(;)|(?=$)'
     'endCaptures':
       '1':
-        'name': 'punctuation.terminator.statement.stylus'
+        'name': 'punctuation.terminator.statement.css'
     'patterns': [
       {
         'include': '#expression'
@@ -471,7 +480,7 @@
     ]
   'rule_at':
     'match': '@([-\\w]+)'
-    'name': 'keyword.stylus'
+    'name': 'keyword.css'
   'rules':
     'patterns': [
       {
@@ -489,7 +498,7 @@
     'name': 'entity.other.attribute-name.class.css'
   'selector_entities':
     'match': '\\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|bgsound|big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|content|data|datalist|dd|decorator|del|details|dfn|dir|div|dl|dt|element|em|embed|fieldset|figcaption|figure|font|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|listing|main|map|mark|marquee|menu|menuitem|meta|meter|nav|nobr|noframes|noscript|object|ol|optgroup|option|output|p|param|plaintext|pre|progress|q|rp|rt|ruby|s|samp|script|section|select|shadow|small|source|spacer|span|strike|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr|xmp|altGlyph|altGlyphDef|altGlyphItem|animate|animateColor|animateMotion|animateTransform|circle|clipPath|color-profile|defs|desc|ellipse|feBlend|feColorMatrix|feComponentTransfer|feComposite|feConvolveMatrix|feDiffuseLighting|feDisplacementMap|feDistantLight|feFlood|feFuncA|feFuncB|feFuncG|feFuncR|feGaussianBlur|feImage|feMerge|feMergeNode|feMorphology|feOffset|fePointLight|feSpecularLighting|feSpotLight|feTile|feTurbulence|filter|font-face|font-face-format|font-face-name|font-face-src|font-face-uri|foreignObject|g|glyph|glyphRef|hkern|image|line|linearGradient|marker|mask|metadata|missing-glyph|mpath|path|pattern|polygon|polyline|radialGradient|rect|set|stop|svg|switch|symbol|text|textPath|tref|tspan|use|view|vkern)\\b'
-    'name': 'entity.name.tag.stylus'
+    'name': 'keyword.control.html.elements'
   'selector_id':
     'captures':
       '1':
@@ -501,50 +510,50 @@
       {
         'match': '(:)(active|checked|default|disabled|empty|enabled|first-child|first-of-type|first|fullscreen|focus|hover|indeterminate|in-range|invalid|last-child|last-of-type|left|link|only-child|only-of-type|optional|out-of-range|read-only|read-write|required|right|root|scope|target|valid|visited)\\b'
         'captures':
-          '1': 'name': 'puncutation.definition.entity.stylus'
-        'name': 'entity.other.attribute-name.pseudo-class.stylus'
+          '1': 'name': 'puncutation.definition.entity.css'
+        'name': 'entity.other.attribute-name.pseudo-class.css'
       }
       {
         'match': '(:?:)(before|after)\\b'
         'captures':
           '1':
-            'name': 'puncutation.definition.entity.stylus'
-        'name': 'entity.other.attribute-name.pseudo-element.stylus'
+            'name': 'puncutation.definition.entity.css'
+        'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {
         'match': '(::)(first-letter|first-number|selection)\\b'
         'captures':
           '1':
-            'name': 'puncutation.definition.entity.stylus'
-        'name': 'entity.other.attribute-name.pseudo-element.stylus'
+            'name': 'puncutation.definition.entity.css'
+        'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {
         'match': '((:)dir)\\s*(?:(\\()(ltr|rtl)?(\\)))?'
         'captures':
           '1':
-            'name': 'entity.other.attribute-name.pseudo-element.stylus'
+            'name': 'entity.other.attribute-name.pseudo-element.css'
           '2':
-            'name': 'puncutation.definition.entity.stylus'
+            'name': 'puncutation.definition.entity.css'
           '3':
-            'name': 'punctuation.definition.parameters.start.begin.stylus'
+            'name': 'punctuation.definition.parameters.start.begin.css'
           '4':
-            'name': 'constant.language.stylus'
+            'name': 'constant.language.css'
           '5':
-            'name': 'punctuation.definition.parameters.end.stylus'
+            'name': 'punctuation.definition.parameters.end.css'
       }
       {
         'match': '((:)lang)\\s*(?:(\\()(\\w+(-\\w+)?)?(\\)))?'
         'captures':
           '1':
-            'name': 'entity.other.attribute-name.pseudo-element.stylus'
+            'name': 'entity.other.attribute-name.pseudo-element.css'
           '2':
-            'name': 'puncutation.definition.entity.stylus'
+            'name': 'puncutation.definition.entity.css'
           '3':
-            'name': 'punctuation.definition.entity.start.stylus'
+            'name': 'punctuation.definition.entity.start.css'
           '4':
-            'name': 'constant.language.stylus'
+            'name': 'constant.language.css'
           '6':
-            'name': 'punctuation.definition.entity.end.stylus'
+            'name': 'punctuation.definition.entity.end.css'
       }
       {
         'include': '#selector_pseudo_nth'
@@ -557,15 +566,15 @@
     'begin': '((:)(?:nth-child|nth-last-child|nth-of-type|nth-last-of-type|nth-match|nth-last-match|nth-column|nth-last-column))\\s*(\\()'
     'beginCaptures':
       '1':
-        'name': 'entity.other.attribute-name.pseudo-element.stylus'
+        'name': 'entity.other.attribute-name.pseudo-element.css'
       '2':
-        'name': 'puncutation.definition.entity.stylus'
+        'name': 'puncutation.definition.entity.css'
       '3':
-        'name': 'punctuation.definition.entity.start.stylus'
+        'name': 'punctuation.definition.entity.start.css'
     'end': '(\\))'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.entity.end.stylus'
+        'name': 'punctuation.definition.entity.end.css'
     'patterns': [
       {
         'include': '#logical_operators'
@@ -575,33 +584,33 @@
       }
       {
         'match': '\\b(odd|even)\\b'
-        'name': 'constant.language.stylus'
+        'name': 'constant.language.css'
       }
       {
         'match': '\\b(\\d+)?n\\b'
         'captures':
           '1':
-            'name': 'constant.numeric.stylus'
-        'name': 'variable.language.stylus'
+            'name': 'constant.numeric.css'
+        'name': 'variable.language.css'
       }
       {
         'match': '\\d+'
-        'name': 'constant.numeric.stylus'
+        'name': 'constant.numeric.css'
       }
     ]
   'selector_pseudo_not':
     'begin': '((:)not)\\s*(\\()'
     'beginCaptures':
       '1':
-        'name': 'entity.other.attribute-name.pseudo-element.stylus'
+        'name': 'entity.other.attribute-name.pseudo-element.css'
       '2':
-        'name': 'puncutation.definition.entity.stylus'
+        'name': 'puncutation.definition.entity.css'
       '3':
-        'name': 'punctuation.definition.entity.start.stylus'
+        'name': 'punctuation.definition.entity.start.css'
     'end': '\\)'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.entity.end.stylus'
+        'name': 'punctuation.definition.entity.end.css'
     'patterns': [
       {
         'include': '#selectors'
@@ -611,11 +620,11 @@
     'begin': '\\[(?=[^\\]]*\\])'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.entity.start.stylus'
+        'name': 'punctuation.definition.entity.start.css'
     'end': '\\]'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.entity.end.stylus'
+        'name': 'punctuation.definition.entity.end.css'
     'patterns': [
       {
         'begin': '(?<=\\[)|(?<=\\{)'
@@ -628,7 +637,7 @@
             'match': '.'
             'captures':
               '0':
-                'name': 'entity.other.attribute-name.stylus'
+                'name': 'entity.other.attribute-name.css'
           }
         ]
       }
@@ -639,7 +648,7 @@
         'match': '([\\\\*^|~]?=)'
         'captures':
           '1':
-            'name': 'punctuation.separator.key-value.stylus'
+            'name': 'punctuation.separator.key-value.css'
       }
       {
         'include': '#string-quoted'
@@ -648,10 +657,10 @@
         'match': '.'
         'captures':
           '0':
-            'name': 'string.unquoted.stylus'
+            'name': 'string.unquoted.css'
       }
     ]
-    'name': 'meta.attribute-selector.stylus'
+    'name': 'meta.attribute-selector.css'
   'selectors':
     'comment': 'Stuff for Selectors.'
     'patterns': [
@@ -675,15 +684,15 @@
       }
       {
         'match': '\\$[\\w$-]+\\b'
-        'name': 'entity.other.placeholder.stylus'
+        'name': 'entity.other.placeholder.css'
       }
       {
         'match': '[:~>]'
-        'name': 'keyword.operator.selector.stylus'
+        'name': 'keyword.operator.selector.css'
       }
       {
         'match': '\\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|bgsound|big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|content|data|datalist|dd|decorator|del|details|dfn|dir|div|dl|dt|element|em|embed|fieldset|figcaption|figure|font|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|listing|main|map|mark|marquee|menu|menuitem|meta|meter|nav|nobr|noframes|noscript|object|ol|optgroup|option|output|p|param|plaintext|pre|progress|q|rp|rt|ruby|s|samp|script|section|select|shadow|small|source|spacer|span|strike|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr|xmp|altGlyph|altGlyphDef|altGlyphItem|animate|animateColor|animateMotion|animateTransform|circle|clipPath|color-profile|defs|desc|ellipse|feBlend|feColorMatrix|feComponentTransfer|feComposite|feConvolveMatrix|feDiffuseLighting|feDisplacementMap|feDistantLight|feFlood|feFuncA|feFuncB|feFuncG|feFuncR|feGaussianBlur|feImage|feMerge|feMergeNode|feMorphology|feOffset|fePointLight|feSpecularLighting|feSpotLight|feTile|feTurbulence|filter|font-face|font-face-format|font-face-name|font-face-src|font-face-uri|foreignObject|g|glyph|glyphRef|hkern|image|line|linearGradient|marker|mask|metadata|missing-glyph|mpath|path|pattern|polygon|polyline|radialGradient|rect|set|stop|svg|switch|symbol|text|textPath|tref|tspan|use|view|vkern)\\b'
-        'name': 'entity.name.tag.stylus'
+        'name': 'entity.name.tag.css'
       }
       {
         'include': '#selector_class'
@@ -695,11 +704,11 @@
         'match': '([\\w\\d_-]+)?(\\&)([\\w\\d_-]+)?'
         'captures':
           '1':
-            'name': 'entity.other.attribute-name.stylus'
+            'name': 'entity.other.attribute-name.css'
           '2':
-            'name': 'variable.language.stylus'
+            'name': 'variable.language.css'
           '3':
-            'name': 'entity.other.attribute-name.stylus'
+            'name': 'entity.other.attribute-name.css'
       }
     ]
   'selectors_css':
@@ -711,52 +720,52 @@
       }
       {
         'match': '\\b(\\d+(\\.\\d+)?%|from|to)\\b'
-        'name': 'entity.other.animation-keyframe.stylus'
+        'name': 'entity.other.animation-keyframe.css'
       }
       {
         'include': '#selectors'
       }
       {
         'match': '.'
-        'name': 'entity.other.attribute-name.stylus'
+        'name': 'entity.other.attribute-name.css'
       }
     ]
     'end': '\\n|$|(?=\\{\\s*\\}.*$)|(?=\\{.*?[:;])|(?=\\{)(?!.+\\}.*$)|(?=;)'
-    'name': 'meta.selector.stylus'
+    # 'name': 'meta.selector.css'
   'string_single':
     'begin': '\''
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.stylus'
+        'name': 'punctuation.definition.string.begin.css'
     'end': '\''
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.stylus'
-    'name': 'string.quoted.single.stylus'
+        'name': 'punctuation.definition.string.end.css'
+    'name': 'string.quoted.single.css'
   'string_double':
     'begin': '"'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.stylus'
+        'name': 'punctuation.definition.string.begin.css'
     'end': '"'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.stylus'
-    'name': 'string.quoted.double.stylus'
+        'name': 'punctuation.definition.string.end.css'
+    'name': 'string.quoted.double.css'
   'tag_parent_reference':
     'match': '[\\&>]'
-    'name': 'punctuation.separator.key-value.stylus'
+    'name': 'punctuation.separator.key-value.css'
   'url':
     'begin': '(url)\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'support.function.misc.css'
       '2':
-        'name': 'punctuation.definition.parameters.start.begin.stylus'
+        'name': 'punctuation.definition.parameters.start.begin.css'
     'end': '(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.definition.parameters.end.stylus'
+        'name': 'punctuation.definition.parameters.end.css'
     'patterns': [
       {
         'include': '#string-quoted'
@@ -774,11 +783,10 @@
         'include': '#variable'
       }
     ]
-    'name': 'entity.function.stylus'
+    'name': 'entity.function.css'
   'variable':
     'captures':
       '1':
-        'name': 'variable.stylus'
+        'name': 'variable.css'
     'match': '\\$[a-zA-Z_-][a-zA-Z0-9_-]*'
-    'name': 'variable.stylus'
-
+    'name': 'variable.css'


### PR DESCRIPTION
Either adjust the file scope to `source.css.less` or wait for https://github.com/atom/autocomplete-css/pull/41 to be merged in (this could be awhile as its a built-in package).

:tada: 

- Adjusted the scope that some patterns were getting to match how language-less works. Property names get highlighted correctly now.

- [ ] I did a find/replace for `'.stylus' => '.css'`. This closely follows how language-less works against the common autocomplete provider. However this is not 100% ideal. We need to undo some of what I did so syntax that is stylus specific (`@extend`, `+tag`, `clearfix()`, etc.) gets marked as `.stylus`. Not entirely necessary but still probably the "right" thing to do.

Fixes: #28 #43 (probably) https://github.com/atom/autocomplete-css/issues/2