### PR TITLE
:bug: fix end match for property values (fixes indent guide for brace-less stylus)

### DIFF
--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -353,7 +353,7 @@
         'beginCaptures':
             '1':
               'name': 'punctuation.separator.key-value.css'
-        'end': '(;|\\n)|(?=\\})|(?=(?<!\\,)\\n)'
+        'end': '(;)|((?<!\\,)\\s*\\n)|(?=\\})'
         'endCaptures':
             '1':
               'name': 'punctuation.terminator.rule.css'


### PR DESCRIPTION
Fixes #47 