### PR TITLE
Support `extends`

### DIFF
--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -525,7 +525,7 @@
         ]
       }
       {
-        'begin': '\\s*(@)(extend)\\b\\s*'
+        'begin': '\\s*(@)(extend|extends)\\b\\s*'
         'beginCaptures':
           '1': 'name': 'punctuation.definition.keyword.stylus'
           '2': 'name': 'keyword.control.at-rule.extend.stylus'

--- a/grammars/stylus.cson
+++ b/grammars/stylus.cson
@@ -525,7 +525,7 @@
         ]
       }
       {
-        'begin': '\\s*(@)(extend|extends)\\b\\s*'
+        'begin': '\\s*(@)(extend[s]?)\\b\\s*'
         'beginCaptures':
           '1': 'name': 'punctuation.definition.keyword.stylus'
           '2': 'name': 'keyword.control.at-rule.extend.stylus'


### PR DESCRIPTION
Source: http://stylus-lang.com/docs/extend.html

> note that @extend and @extends are equal, one is just an alias of another