### PR TITLE
added mixin and selector autosuggestions

### DIFF
--- a/settings/language-stylus.cson
+++ b/settings/language-stylus.cson
@@ -29,3 +29,9 @@
       'variable':
         'selector': '.variable'
         'typePriority': 2
+      'mixin':
+          'selector': '.entity.name.function, .support.function'
+          'typePriority': 3
+      'selector':
+          'selector': '.attribute-name.id, .attribute-name.class'
+          'typePriority': 1


### PR DESCRIPTION
Hello and thank you for this package. Mixin name's and selector weren't appeared in autosuggestion box while typing(as a result i was unable to autocomplete them). I really miss this feature. So this should fix that. Sorry for any mistakes. English is not my native language.