### PR TITLE
Fix indent pattern to avoid matching decimal values.

### DIFF
--- a/settings/language-stylus.cson
+++ b/settings/language-stylus.cson
@@ -10,7 +10,7 @@
         | (\\{)
         | (\\*)
         | (\\&)
-        | ((\\.)[a-zA-Z0-9_-]+(?:(?<=\\w)(?![\\w-])))
+        | ((?<name>[a-zA-Z0-9_-]+(?:(?<=\\w)(?![\\w-]))){0}(((?<!\\d)\\.\\g<name>)|(?<=\\d)\\.\\D\\g<name>))
         | ((\\#[a-zA-Z][a-zA-Z0-9_-]*)(?:(?<=\\w)(?![\\w-])))
         | ((:+)(after|before|content|first-letter|first-line|host|(-(moz|webkit|ms)-)?selection)(?:(?<=\\w)(?![\\w-])))
         | ((:)((first|last)-child|(first|last|only)-of-type|empty|root|target|first|left|right)\\b)


### PR DESCRIPTION
This PR tweaks the `increaseIndentPattern` regex in hopes of keeping it from matching lines like `font-size 1.2rem`. It requires anything that looks like a class name to either not be preceded by a digit at all followed by a period, or to be preceded by a digit, a period, and a non-digit.

This seemed to cover most of the corner cases I could think up, but I'm happy to put a little more thought into it if I missed anything! Here it is in action:

<img width="882" alt="screen shot 2" src="https://user-images.githubusercontent.com/2207980/27076413-21f4e084-4ffb-11e7-807e-06d5789b8ee2.png">

![screenflow](https://user-images.githubusercontent.com/2207980/27076414-23251cf8-4ffb-11e7-80bb-4833f208ea20.gif)